### PR TITLE
Add MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "cifuzz",
+    version = "1.0",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.11")


### PR DESCRIPTION
Adds a MODULE.bazel file so that cifuzz-bazel can be imported as a bazel module.
